### PR TITLE
Create new figure

### DIFF
--- a/src/cplot/_main.py
+++ b/src/cplot/_main.py
@@ -311,6 +311,8 @@ def _plot(
 
     asc = abs_scaling if callable(abs_scaling) else _abs_scaling_from_float(abs_scaling)
 
+    plt.figure()
+
     _plot_colors(
         fz,
         extent,


### PR DESCRIPTION
When creating multiple cplots in Jupyter Notebook with `ipympl` and `%matplotlib widget`, the
first plot looks good. The second will be overlayed to the first, and so on, making the plot
unreadable.

This PR fixes this behaviour: a new `matplotlib` figure will be created everytime `cplot.plot`
is executed.

This solves issue #60 