### PR TITLE
plot_phase should be plot_arg

### DIFF
--- a/src/cplot/_main.py
+++ b/src/cplot/_main.py
@@ -417,7 +417,7 @@ def plot_arg(*args, add_colorbars: bool = True, **kwargs):
 
 
 # "Phase plot" is a common name for this kind of plots
-plot_phase = plot_abs
+plot_phase = plot_arg
 
 
 # only show the phase, with some default value adjustments


### PR DESCRIPTION
Phase plots show the phase of complex numbers, i.e. a representation of the arg. `plot_phase` did just that until a renaming accident happened in ff334cb ("add plot_contours()", 2021-10-29). Restore the proper aliasing.